### PR TITLE
Workaround for initializing PostgREST with Vertica

### DIFF
--- a/install_complex_types_udx.sh
+++ b/install_complex_types_udx.sh
@@ -1,0 +1,2 @@
+# NOTE: This MUST be run outside of the nix-shell environment
+(cd $SOURCE/SQLTest && make install_ComplexTypes)

--- a/nix/tools/loadtest.nix
+++ b/nix/tools/loadtest.nix
@@ -47,7 +47,7 @@ let
       ''
         # previously required settings to make this work with older branches
         export PGRST_DB_ANON_ROLE="postgrest_test_anonymous"
-        export PGRST_DB_URI="postgresql://"
+        export PGRST_DB_URI="postgres://authenticator:mysecretpassword@localhost:5433/verticadb21214"
         export PGRST_DB_SCHEMAS="test"
 
         export PGRST_DB_CONFIG="false"

--- a/setup_vertica_demo.sh
+++ b/setup_vertica_demo.sh
@@ -1,0 +1,42 @@
+vsql -c "
+create table public.pg_db_role_setting (
+  setdatabase integer,
+  setrole integer,
+  setconfig ARRAY[varchar]
+);
+create table public.pg_database (
+  oid integer,
+  datname varchar,
+  datdba integer,
+  encoding integer,
+  datlocprovider char,
+  datistemplate boolean,
+  datallowconn boolean,
+  datconnlimit integer,
+  datfrozenxid integer,
+  datminmxid integer,
+  dattablespace integer,
+  datcollate varchar,
+  datctype varchar,
+  daticulocale varchar,
+  datcollversion varchar,
+  datacl ARRAY[varchar]
+);
+
+select set_vertica_options('Basic', 'DISABLE_DEPARSE_CHECK');
+create schema api;
+create table api.todos (
+  id identity primary key,
+  done boolean not null default false,
+  task varchar not null,
+  due timestamptz
+);
+insert into api.todos (task) values ('finish tutorial 0');
+insert into api.todos (task) values ('pat self on back');
+create role web_anon;
+grant usage on schema api to web_anon;
+grant select on api.todos to web_anon;
+CREATE USER authenticator IDENTIFIED BY 'mysecretpassword';
+grant web_anon to authenticator;
+GRANT SELECT ON ALL TABLES IN SCHEMA public to authenticator;
+"

--- a/src/PostgREST/CLI.hs
+++ b/src/PostgREST/CLI.hs
@@ -8,18 +8,18 @@ module PostgREST.CLI
   , readCLIShowHelp
   ) where
 
-import qualified Data.Aeson                 as JSON
+-- import qualified Data.Aeson                 as JSON
 import qualified Data.ByteString.Char8      as BS
-import qualified Data.ByteString.Lazy       as LBS
-import qualified Hasql.Transaction.Sessions as SQL
+-- import qualified Data.ByteString.Lazy       as LBS
+-- import qualified Hasql.Transaction.Sessions as SQL
 import qualified Options.Applicative        as O
 
-import Data.Text.IO (hPutStrLn)
+-- import Data.Text.IO (hPutStrLn)
 import Text.Heredoc (str)
 
-import PostgREST.AppState    (AppState)
+-- import PostgREST.AppState    (AppState)
 import PostgREST.Config      (AppConfig (..))
-import PostgREST.SchemaCache (querySchemaCache)
+-- import PostgREST.SchemaCache (querySchemaCache)
 import PostgREST.Version     (prettyVersion)
 import PostgREST.Workers     (reReadConfig)
 
@@ -45,10 +45,11 @@ main installSignalHandlers runAppWithSocket CLI{cliCommand, cliPath} = do
       CmdDumpConfig -> do
         when configDbConfig $ reReadConfig True appState
         putStr . Config.toText =<< AppState.getConfig appState
-      CmdDumpSchema -> putStrLn =<< dumpSchema appState
+      CmdDumpSchema -> pure () -- putStrLn =<< dumpSchema appState
       CmdRun -> App.run installSignalHandlers runAppWithSocket appState)
 
 -- | Dump SchemaCache schema to JSON
+{-
 dumpSchema :: AppState -> IO LBS.ByteString
 dumpSchema appState = do
   AppConfig{..} <- AppState.getConfig appState
@@ -65,6 +66,7 @@ dumpSchema appState = do
       hPutStrLn stderr $ "An error ocurred when loading the schema cache:\n" <> show e
       exitFailure
     Right sCache -> return $ JSON.encode sCache
+-}
 
 -- | Command line interface options
 data CLI = CLI

--- a/src/PostgREST/Workers.hs
+++ b/src/PostgREST/Workers.hs
@@ -13,7 +13,7 @@ import qualified Data.ByteString            as BS
 import qualified Data.Text                  as T
 import qualified Hasql.Notifications        as SQL
 import qualified Hasql.Session              as SQL
-import qualified Hasql.Transaction.Sessions as SQL
+-- import qualified Hasql.Transaction.Sessions as SQL
 import qualified Network.HTTP.Types.Status  as HTTP
 import qualified Network.Wai                as Wai
 import qualified Network.Wai.Handler.Warp   as Warp
@@ -28,9 +28,9 @@ import Network.Socket.ByteString
 import PostgREST.AppState         (AppState)
 import PostgREST.Config           (AppConfig (..), readAppConfig)
 import PostgREST.Config.Database  (queryDbSettings, queryPgVersion)
-import PostgREST.Config.PgVersion (PgVersion (..), minimumPgVersion)
+import PostgREST.Config.PgVersion (PgVersion (..))
 import PostgREST.Error            (checkIsFatal)
-import PostgREST.SchemaCache      (querySchemaCache)
+-- import PostgREST.SchemaCache      (querySchemaCache)
 
 import qualified PostgREST.AppState as AppState
 
@@ -45,10 +45,12 @@ data ConnectionStatus
   deriving (Eq)
 
 -- | Schema cache status
+{-
 data SCacheStatus
   = SCLoaded
   | SCOnRetry
   | SCFatalFail
+-}
 
 -- | The purpose of this worker is to obtain a healthy connection to pg and an
 -- up-to-date schema cache(SchemaCache).  This method is meant to be called
@@ -91,7 +93,7 @@ connectionWorker appState = do
           -- this could be fail because the connection drops, but the
           -- loadSchemaCache will pick the error and retry again
           when configDbConfig $ reReadConfig False appState
-          scStatus <- loadSchemaCache appState
+          {- scStatus <- loadSchemaCache appState
           case scStatus of
             SCLoaded ->
               -- do nothing and proceed if the load was successful
@@ -102,6 +104,7 @@ connectionWorker appState = do
             SCFatalFail ->
               -- die if our schema cache query has an error
               killThread $ AppState.getMainThreadId appState
+          -}
 
 -- | Repeatedly flush the pool, and check if a connection from the
 -- pool allows access to the PostgreSQL database.
@@ -134,12 +137,12 @@ establishConnection appState =
             Nothing ->
               return NotConnected
         Right version ->
-          if version < minimumPgVersion then
+          {--if version < minimumPgVersion then
             return . FatalConnectionError $
               "Cannot run in this PostgreSQL version, PostgREST needs at least "
               <> pgvName minimumPgVersion
-          else
-            return . Connected  $ version
+          else--}
+          return . Connected  $ version
 
     shouldRetry :: RetryStatus -> ConnectionStatus -> IO Bool
     shouldRetry rs isConnSucc = do
@@ -154,6 +157,7 @@ establishConnection appState =
       return itShould
 
 -- | Load the SchemaCache by using a connection from the pool.
+{-
 loadSchemaCache :: AppState -> IO SCacheStatus
 loadSchemaCache appState = do
   AppConfig{..} <- AppState.getConfig appState
@@ -179,6 +183,7 @@ loadSchemaCache appState = do
       AppState.putSchemaCache appState (Just sCache)
       AppState.logWithZTime appState "Schema cache loaded"
       return SCLoaded
+-}
 
 runListener :: AppConfig -> AppState -> IO ()
 runListener AppConfig{configDbChannelEnabled} appState =

--- a/test/io/config.py
+++ b/test/io/config.py
@@ -20,7 +20,7 @@ def dburi():
     dbname = os.environ["PGDATABASE"]
     host = os.environ["PGHOST"]
     user = os.environ["PGUSER"]
-    return f"postgresql://?dbname={dbname}&host={host}&user={user}".encode()
+    return f"postgres://authenticator:mysecretpassword@localhost:5433/verticadb21214".encode()
 
 
 @pytest.fixture

--- a/test/spec/SpecHelper.hs
+++ b/test/spec/SpecHelper.hs
@@ -88,7 +88,7 @@ baseCfg = let secret = Just $ encodeUtf8 "reallyreallyreallyreallyverysafe" in
   , configDbRootSpec            = Nothing
   , configDbSchemas             = fromList ["test"]
   , configDbConfig              = False
-  , configDbUri                 = "postgresql://"
+  , configDbUri                 = "postgres://authenticator:mysecretpassword@localhost:5433/verticadb21214"
   , configDbUseLegacyGucs       = True
   , configFilePath              = Nothing
   , configJWKS                  = parseSecret <$> secret

--- a/tutorial.conf
+++ b/tutorial.conf
@@ -1,0 +1,4 @@
+db-uri = "postgres://authenticator:mysecretpassword@localhost:5433/verticadb21214"
+db-schemas = "api"
+db-anon-role = "web_anon"
+


### PR DESCRIPTION
Included are all changes made to the PostgREST source to allow it to initialize when using Vertica as the backend database. In addition, changes have been made to allow the various test suites to run against a local instance of Vertica.

Also, temporary convenience scripts are included to allow demoing to go smoothly. These should be deleted later:
tutorial.conf
setup_vertica_demo.sh
install_complex_types_udx.sh